### PR TITLE
Add double tap callback

### DIFF
--- a/Examples/LazyPagerExampleApp/FullTestView.swift
+++ b/Examples/LazyPagerExampleApp/FullTestView.swift
@@ -59,6 +59,9 @@ struct FullTestView: View {
             .onTap {
                 print("tap")
             }
+            .onDoubleTap {
+                print("double tap")
+            }
             .shouldLoadMore(on: .lastElement(minus: 2)) {
                 data.append(Foo(img: "nora4", idx: data.count))
             }

--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ For a full working example, [open the sample project](https://github.com/gh123ma
 - Horizontal or Vertical paging.
 - Lazy loaded views are disposed when they are outside of the pre-load frame to conserve resources. 
 - Enable zooming and panning with `.zoomable(min: CGFloat, max: CGFloat)`.
-- Double tap to zoom is also supported.
+- Double tap to zoom is also supported through `.zoomable` modifier.
 - Notifies when to load more content with `.shouldLoadMore`.
 - Notifies when you swipe past the beginning or end of data with `.overscroll`.
 - Animate page transitions by using `withAnimation` when changing the page index. 
 - Works with `.ignoresSafeArea()` (or not) to get a true full screen view.
 - Drag to dismiss is supported with `.onDismiss` - Supply a binding opacity value to control the background opacity during the transition. 
 - Tap events are handled internally, so use `.onTap` to handle single taps (useful for hiding and showing UI).
+- Use `.onDoubleTap` to get notified on double taps.
 - Use `.settings` to [modify advanced settings](https://github.com/gh123man/SwiftUI-LazyPager/blob/master/Sources/LazyPager/LazyPager.swift#L67).
 - Use `.absoluteContentPosition` to subscribe to content position updates (the index + the offset while paging)
 - Use `.onZoom` to get notified of the current zoom level

--- a/Sources/LazyPager/LazyPager.swift
+++ b/Sources/LazyPager/LazyPager.swift
@@ -43,6 +43,9 @@ public struct Config<Element> {
     /// Called when tapping once
     public var tapCallback: (() -> ())?
     
+    /// Called when tapping twice
+    public var doubleTapCallback: (() -> ())?
+    
     /// The offset used to trigger load loadMoreCallback
     public var loadMoreOn: LoadMore = .lastElement(minus: 3)
     
@@ -135,6 +138,12 @@ public extension LazyPager {
     func onTap(_ callback: @escaping () -> ()) -> LazyPager {
         var this = self
         this.config.tapCallback = callback
+        return this
+    }
+    
+    func onDoubleTap(_ callback: @escaping () -> ()) -> LazyPager {
+        var this = self
+        this.config.doubleTapCallback = callback
         return this
     }
     

--- a/Sources/LazyPager/ZoomableView.swift
+++ b/Sources/LazyPager/ZoomableView.swift
@@ -112,19 +112,23 @@ class ZoomableView<Element, Content: View>: UIScrollView, UIScrollViewDelegate {
             v.heightAnchor.constraint(equalToConstant: constant)
         ])
         
-        let singleTapGesture = UITapGestureRecognizer(target: self, action: #selector(singleTap(_:)))
-        singleTapGesture.numberOfTapsRequired = 1
-        singleTapGesture.numberOfTouchesRequired = 1
-        addGestureRecognizer(singleTapGesture)
+        var singleTapGesture: UITapGestureRecognizer?
+        if config.tapCallback != nil {
+            let gesture = UITapGestureRecognizer(target: self, action: #selector(singleTap(_:)))
+            gesture.numberOfTapsRequired = 1
+            gesture.numberOfTouchesRequired = 1
+            addGestureRecognizer(gesture)
+            singleTapGesture = gesture
+        }
                 
         func setupDoubleTapGesture() {
             let doubleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(onDoubleTap(_:)))
             doubleTapRecognizer.numberOfTapsRequired = 2
             doubleTapRecognizer.numberOfTouchesRequired = 1
-            addGestureRecognizer(doubleTapRecognizer)
-            
-            singleTapGesture.require(toFail: doubleTapRecognizer)
+            addGestureRecognizer(doubleTapRecognizer)            
+            singleTapGesture?.require(toFail: doubleTapRecognizer)
         }
+        
         if case .scale = doubleTap {
             setupDoubleTapGesture()
         } else if config.doubleTapCallback != nil {

--- a/Sources/LazyPager/ZoomableView.swift
+++ b/Sources/LazyPager/ZoomableView.swift
@@ -152,7 +152,9 @@ class ZoomableView<Element, Content: View>: UIScrollView, UIScrollViewDelegate {
         config.tapCallback?()
     }
     
-    @objc func onDoubleTap(_ recognizer:UITapGestureRecognizer) {
+    @objc func onDoubleTap(_ recognizer: UITapGestureRecognizer) {
+        config.doubleTapCallback?()
+        
         if case let .scale(scale) = doubleTap {
             let pointInView = recognizer.location(in: view)
             zoom(at: pointInView, scale: scale)

--- a/Sources/LazyPager/ZoomableView.swift
+++ b/Sources/LazyPager/ZoomableView.swift
@@ -116,14 +116,19 @@ class ZoomableView<Element, Content: View>: UIScrollView, UIScrollViewDelegate {
         singleTapGesture.numberOfTapsRequired = 1
         singleTapGesture.numberOfTouchesRequired = 1
         addGestureRecognizer(singleTapGesture)
-        
-        if case .scale = doubleTap {
+                
+        func setupDoubleTapGesture() {
             let doubleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(onDoubleTap(_:)))
             doubleTapRecognizer.numberOfTapsRequired = 2
             doubleTapRecognizer.numberOfTouchesRequired = 1
             addGestureRecognizer(doubleTapRecognizer)
             
             singleTapGesture.require(toFail: doubleTapRecognizer)
+        }
+        if case .scale = doubleTap {
+            setupDoubleTapGesture()
+        } else if config.doubleTapCallback != nil {
+            setupDoubleTapGesture()
         }
         
         DispatchQueue.main.async {


### PR DESCRIPTION
Hi :),

here's an implementation for exposing a double tap modifier to the user.

While testing that, I noticed it generally works, but I've ran into another wild SwiftUI issue: 
I had the on tap gesture trigger a "toggle like" network call, after which it changes the model and updates the view. But with the UITapGestureRecognizer it would only work the first time. Subsequent double taps would fire the callback but didn't update the SwiftUI view.

I don't know what was the problem here, but I suspect UIKit and SwiftUI getting out of sync somehow. Maybe the gesture recognizer target must be the Coordinator object from the UIViewControllerRepresentable?

I worked around by making both UITapGestureRecognizers attach only when needed. So I could use native `.onTapGesture` modifiers which worked.

Feel free to look over my code and take, edit or reject anything you want.