### PR TITLE
fix: unexpected ',' separator

### DIFF
--- a/Sources/LazyPager/ZoomableView.swift
+++ b/Sources/LazyPager/ZoomableView.swift
@@ -269,7 +269,7 @@ class ZoomableView<Element, Content: View>: UIScrollView, UIScrollViewDelegate, 
                 top: top,
                 left: left,
                 bottom: top,
-                right: left,
+                right: left
             )
             
             UIView.animate(withDuration: 0.3) {


### PR DESCRIPTION
<img width="908" height="327" alt="image" src="https://github.com/user-attachments/assets/ef23342a-3da5-4d96-8ae7-4455a5b0a960" />
